### PR TITLE
POC Forma Build types configuration API

### DIFF
--- a/application/binary/build.gradle.kts
+++ b/application/binary/build.gradle.kts
@@ -1,3 +1,5 @@
+import tools.forma.android.utils.BuildConfiguration
+
 androidBinary(
     packageName = "com.stepango.blockme.app",
     owner = Teams.core,
@@ -23,5 +25,85 @@ androidBinary(
         project(":common:progressbar:databinding"),
         project(":core:mvvm:library"),
         project(":core:di:library")
+    ),
+
+    /**
+     * Version #1. Configuration build types
+     *
+     * Using simple types, pass arguments fo configuration
+     */
+    buildConfiguration = BuildConfiguration(
+        BuildType(
+            name = BuildTypeName(
+                id = "debug",
+                suffix = ".debug"
+            ),
+            singingConfig = SigningConfig(
+                name = "Debug",
+                keystore = "debug-keystore.properties"
+            ),
+        ),
+
+        BuildType(
+            name = BuildTypeName(
+                id = "release",
+                suffix = ".release"
+            ),
+            singingConfig = SigningConfig(
+                name = "Live",
+                keystore = "release-keystore.properties"
+            ),
+            optimizeConfig = OptimizeConfig(
+                othersProguardRules = "proguard-rules.pro",
+                shrinkCode = true,
+                shrinkResorces = true
+            )
+        ),
+
+        BuildType(
+            name = BuildTypeName(
+                id = "custom",
+                suffix = ".custom"
+            ),
+            singingConfig = SigningConfig(
+                name = "Custom",
+                keystore = "debug-keystore.properties"
+            )
+        )
+    ),
+
+    /**
+     * Version #2. Configuration build types
+     *
+     * Using aggregates types which could be encapsulate some boilerplate logic. For example, types names.
+     */
+    buildConfiguration = BuildConfiguration(
+        DebugBuildType(
+            suffix = ".debug"
+            singingConfig = DebugSigningConfig(
+                keystore = "debug-keystore.properties"
+            ),
+        ),
+
+        ReleaseBuildType(
+            suffix = ".release"
+            singingConfig = ReleaseSigningConfig(
+                keystore = "release-keystore.properties"
+            ),
+            optimizeConfig = OptimizeConfig(
+                othersProguardRules = "proguard-rules.pro",
+                shrinkCode = true,
+                shrinkResorces = true
+            )
+        ),
+
+        CustomBuildType(
+            name = "custom",
+            suffix = ".custom"
+            signingConfig = SigninConfig(
+                name = "Custom",
+                keystore = "debug-keystore.properties"
+            )
+        )
     )
 )


### PR DESCRIPTION
Please, take a look API POC for build types configuration. Need your opinion.
Next move, is an implementation one of approved version

Behavior support:
- creation build types
- secure configuration keystore settings from local/remote file
- setup configs for shrink, obfuscate, optimizations