### PR TITLE
Manifest generation refactoring

### DIFF
--- a/application/build.gradle.kts
+++ b/application/build.gradle.kts
@@ -1,3 +1,5 @@
+import java.util.Properties
+
 buildscript {
     repositories {
         google()
@@ -9,18 +11,17 @@ buildscript {
     }
 }
 
-val properties = java.util.Properties()
-properties.load(project.rootProject.file("local.properties").inputStream())
-val agpVersion: String? = properties.getProperty("agpVersion")
-val kotlinVersion: String? = properties.getProperty("kotlinVersion")
+val properties = Properties()
+val file: File = project.rootProject.file("local.properties")
+if (file.exists()) properties.load(file.inputStream())
 
 // Enjoy easiest way to configure your Android project
 androidProjectConfiguration(
     minSdk = 21,
     targetSdk = 29,
     compileSdk = 29,
-    kotlinVersion = kotlinVersion ?: "1.4.21",
-    agpVersion = agpVersion ?: "4.2.0-beta02",
+    kotlinVersion = properties.getProperty("kotlinVersion", "1.4.21"),
+    agpVersion = properties.getProperty("agpVersion",  "4.2.0-beta02"),
     versionCode = 1,
     versionName = "1.0",
     dataBinding = true

--- a/application/build.gradle.kts
+++ b/application/build.gradle.kts
@@ -13,7 +13,7 @@ buildscript {
 
 val properties = Properties()
 val file: File = project.rootProject.file("local.properties")
-if (file.exists()) properties.load(file.inputStream())
+if (file.exists()) file.inputStream().use { properties.load(it) }
 
 // Enjoy easiest way to configure your Android project
 androidProjectConfiguration(
@@ -21,7 +21,7 @@ androidProjectConfiguration(
     targetSdk = 29,
     compileSdk = 29,
     kotlinVersion = properties.getProperty("kotlinVersion", "1.4.21"),
-    agpVersion = properties.getProperty("agpVersion",  "4.2.0-beta02"),
+    agpVersion = properties.getProperty("agpVersion", "4.2.0-beta02"),
     versionCode = 1,
     versionName = "1.0",
     dataBinding = true

--- a/application/build.gradle.kts
+++ b/application/build.gradle.kts
@@ -4,18 +4,23 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath("androidx.navigation:navigation-safe-args-gradle-plugin:2.3.2")
-        classpath("com.google.firebase:firebase-crashlytics-gradle:2.4.1")
+        classpath("androidx.navigation:navigation-safe-args-gradle-plugin:2.3.3")
+        classpath("com.google.firebase:firebase-crashlytics-gradle:2.5.0")
     }
 }
+
+val properties = java.util.Properties()
+properties.load(project.rootProject.file("local.properties").inputStream())
+val agpVersion: String? = properties.getProperty("agpVersion")
+val kotlinVersion: String? = properties.getProperty("kotlinVersion")
 
 // Enjoy easiest way to configure your Android project
 androidProjectConfiguration(
     minSdk = 21,
     targetSdk = 29,
     compileSdk = 29,
-    kotlinVersion = "1.4.21",
-    agpVersion = "4.2.0-beta02",
+    kotlinVersion = kotlinVersion ?: "1.4.21",
+    agpVersion = agpVersion ?: "4.2.0-beta02",
     versionCode = 1,
     versionName = "1.0",
     dataBinding = true

--- a/plugins/android/src/main/java/androidApp.kt
+++ b/plugins/android/src/main/java/androidApp.kt
@@ -42,6 +42,7 @@ fun Project.androidApp(
         testInstrumentationRunner,
         consumerMinificationFiles,
         manifestPlaceholders,
+        // AndroidApp should always use custom manifest
         generateManifest = false
     )
     applyFeatures(

--- a/plugins/android/src/main/java/tools/forma/android/feature/AndroidLibrary.kt
+++ b/plugins/android/src/main/java/tools/forma/android/feature/AndroidLibrary.kt
@@ -30,9 +30,8 @@ fun androidLibraryFeatureDefinition(
     featureConfiguration = featureConfiguration,
     configuration = { extension, feature, project, formaConfiguration ->
         with(extension) {
-            if (feature.generateManifest) {
-                applyManifestGenerationFeature(project, feature.packageName)
-            }
+            maybeGenerateManifest(project, feature)
+
             compileSdkVersion(formaConfiguration.compileSdk)
 
             defaultConfig.applyFrom(
@@ -51,14 +50,12 @@ fun androidLibraryFeatureDefinition(
     }
 )
 
-private fun LibraryExtension.applyManifestGenerationFeature(
+private fun LibraryExtension.maybeGenerateManifest(
     project: Project,
-    packageName: String
+    feature: AndroidLibraryFeatureConfiguration
 ) {
-    val manifestFile = manifestFile(project.buildDir, packageName)
-    project.beforeEvaluate {
-        populateManifest(manifestFile, packageName)
-    }
+    val manifestFile = manifestFile(project.buildDir, feature.packageName)
+    populateManifest(manifestFile, feature.packageName)
     sourceSets {
         /**
          * Manifest file resolved during configuration,

--- a/plugins/android/src/main/java/tools/forma/android/feature/AndroidLibrary.kt
+++ b/plugins/android/src/main/java/tools/forma/android/feature/AndroidLibrary.kt
@@ -8,6 +8,7 @@ import tools.forma.android.utils.applyFrom
 import tools.forma.validation.Validator
 import tools.forma.validation.validator
 import java.io.File
+import org.gradle.api.Project
 
 class AndroidLibraryFeatureConfiguration(
     val packageName: String,
@@ -29,6 +30,9 @@ fun androidLibraryFeatureDefinition(
     featureConfiguration = featureConfiguration,
     configuration = { extension, feature, project, formaConfiguration ->
         with(extension) {
+            if (feature.generateManifest) {
+                applyManifestGenerationFeature(project, feature.packageName)
+            }
             compileSdkVersion(formaConfiguration.compileSdk)
 
             defaultConfig.applyFrom(
@@ -43,20 +47,29 @@ fun androidLibraryFeatureDefinition(
 
             buildFeatures.dataBinding = feature.dataBinding
             buildFeatures.viewBinding = feature.viewBinding
-
-            if (feature.generateManifest) {
-                val path = generateManifest(project.buildDir, feature.packageName)
-                sourceSets {
-                    /**
-                     * Manifest file resolved during configuration,
-                     * so we need to create file before we get into plugin is configured
-                     */
-                    getByName("main").manifest.srcFile(path)
-                }
-            }
         }
     }
 )
+
+private fun LibraryExtension.applyManifestGenerationFeature(
+    project: Project,
+    packageName: String
+) {
+    val manifestFile = manifestFile(project.buildDir, packageName)
+    project.beforeEvaluate {
+        populateManifest(manifestFile, packageName)
+    }
+    sourceSets {
+        /**
+         * Manifest file resolved during configuration,
+         * so we need to create file before we get into plugin is configured
+         */
+        getByName("main").manifest.srcFile(manifestFile.path)
+    }
+}
+
+fun manifestFile(buildDir: File, packageName: String) =
+    File(buildDir, "tmp/manifest/${packageName}.xml")
 
 /**
  * Manifest file generated and added it to sourceSet
@@ -64,16 +77,15 @@ fun androidLibraryFeatureDefinition(
  * @param packageName - will be injected to manifest template
  * @return path to generated file
  */
-private fun generateManifest(
-    buildDir: File,
+private fun populateManifest(
+    manifestFile: File,
     packageName: String
 ): String {
     /**
      * Some naive caching here, file name equals package name
      * We create new file only if package is changed or on first build
      */
-    val tmpManifest = File(buildDir, "tmp/manifest/${packageName}.xml")
-    with(tmpManifest) {
+    with(manifestFile) {
         if (!exists()) {
             parentFile.mkdirs()
             createNewFile()
@@ -84,5 +96,5 @@ private fun generateManifest(
             )
         }
     }
-    return tmpManifest.path
+    return manifestFile.path
 }


### PR DESCRIPTION
Instead of generating manifest during the configuration phase, I've used the `beforeEvaluate` callback, so it's now moved to the initialization phase which potentially should play much better with default Gradle behavior

Turn out it was a bad idea, before evaluating callback was set during the configuration stage and seems like never triggered. Probably It would make sense to try to set it through `subProjects` callback. 