### PR TITLE
Add manifest validation, replace manifest build dir generation

### DIFF
--- a/application/build.gradle.kts
+++ b/application/build.gradle.kts
@@ -23,5 +23,6 @@ androidProjectConfiguration(
     versionCode = 1,
     versionName = "1.0",
     dataBinding = true,
-    validateManifestPackages = true
+    validateManifestPackages = true,
+    generateMissedManifests = true
 )

--- a/application/build.gradle.kts
+++ b/application/build.gradle.kts
@@ -21,8 +21,9 @@ androidProjectConfiguration(
     targetSdk = 29,
     compileSdk = 29,
     kotlinVersion = properties.getProperty("kotlinVersion", "1.4.21"),
-    agpVersion = properties.getProperty("agpVersion", "7.0.0-beta04"),
+    agpVersion = properties.getProperty("agpVersion", "7.0.0"),
     versionCode = 1,
     versionName = "1.0",
-    dataBinding = true
+    dataBinding = true,
+    validateManifestPackages = true
 )

--- a/application/common/extensions/android-util/src/main/AndroidManifest.xml
+++ b/application/common/extensions/android-util/src/main/AndroidManifest.xml
@@ -1,0 +1,1 @@
+<manifest package="com.stepango.blockme.common.extensions.android.util"/>

--- a/application/common/extensions/databinding-adapter/src/main/AndroidManifest.xml
+++ b/application/common/extensions/databinding-adapter/src/main/AndroidManifest.xml
@@ -1,0 +1,1 @@
+<manifest package="com.stepango.blockme.common.extensions.databinding.adapter"/>

--- a/application/common/placeholder/res/src/main/AndroidManifest.xml
+++ b/application/common/placeholder/res/src/main/AndroidManifest.xml
@@ -1,0 +1,1 @@
+<manifest package="com.stepango.blockme.common.placeholder.res"/>

--- a/application/common/progressbar/databinding/src/main/AndroidManifest.xml
+++ b/application/common/progressbar/databinding/src/main/AndroidManifest.xml
@@ -1,0 +1,1 @@
+<manifest package="com.stepango.blockme.common.progressbar.databinding"/>

--- a/application/common/progressbar/res/src/main/AndroidManifest.xml
+++ b/application/common/progressbar/res/src/main/AndroidManifest.xml
@@ -1,0 +1,1 @@
+<manifest package="com.stepango.common.progressbar.res"/>

--- a/application/common/recyclerview/widget/src/main/AndroidManifest.xml
+++ b/application/common/recyclerview/widget/src/main/AndroidManifest.xml
@@ -1,0 +1,1 @@
+<manifest package="com.stepango.blockme.common.recyclerview.widget"/>

--- a/application/core/di/library/src/main/AndroidManifest.xml
+++ b/application/core/di/library/src/main/AndroidManifest.xml
@@ -1,0 +1,1 @@
+<manifest package="com.stepango.blockme.core.di.library"/>

--- a/application/core/mvvm/library/src/main/AndroidManifest.xml
+++ b/application/core/mvvm/library/src/main/AndroidManifest.xml
@@ -1,0 +1,1 @@
+<manifest package="com.stepango.blockme.core.mvvm.library"/>

--- a/application/core/navigation/library/src/main/AndroidManifest.xml
+++ b/application/core/navigation/library/src/main/AndroidManifest.xml
@@ -1,0 +1,1 @@
+<manifest package="com.stepango.blockme.core.navigation.library"/>

--- a/application/core/theme/android-util/src/main/AndroidManifest.xml
+++ b/application/core/theme/android-util/src/main/AndroidManifest.xml
@@ -1,0 +1,1 @@
+<manifest package="com.stepango.blockme.core.theme.android.util"/>

--- a/application/core/theme/res/src/main/AndroidManifest.xml
+++ b/application/core/theme/res/src/main/AndroidManifest.xml
@@ -1,0 +1,1 @@
+<manifest package="com.stepango.blockme.core.theme.android.res"/>

--- a/application/feature/characters/core/impl/src/main/AndroidManifest.xml
+++ b/application/feature/characters/core/impl/src/main/AndroidManifest.xml
@@ -1,0 +1,1 @@
+<manifest package="com.stepango.blockme.feature.characters.core.impl"/>

--- a/application/feature/characters/detail/databinding/src/main/AndroidManifest.xml
+++ b/application/feature/characters/detail/databinding/src/main/AndroidManifest.xml
@@ -1,0 +1,1 @@
+<manifest package="com.stepango.blockme.feature.characters.detail.databinding"/>

--- a/application/feature/characters/detail/impl/src/main/AndroidManifest.xml
+++ b/application/feature/characters/detail/impl/src/main/AndroidManifest.xml
@@ -1,0 +1,1 @@
+<manifest package="com.stepango.blockme.feature.characters.detail.impl"/>

--- a/application/feature/characters/detail/res/src/main/AndroidManifest.xml
+++ b/application/feature/characters/detail/res/src/main/AndroidManifest.xml
@@ -1,0 +1,1 @@
+<manifest package="com.stepango.blockme.feature.character.detail.res"/>

--- a/application/feature/characters/favorite/databinding/src/main/AndroidManifest.xml
+++ b/application/feature/characters/favorite/databinding/src/main/AndroidManifest.xml
@@ -1,0 +1,1 @@
+<manifest package="com.stepango.blockme.feature.favorite.res"/>

--- a/application/feature/characters/favorite/impl/src/main/AndroidManifest.xml
+++ b/application/feature/characters/favorite/impl/src/main/AndroidManifest.xml
@@ -1,0 +1,1 @@
+<manifest package="com.stepango.blockme.feature.characters.favorite.impl"/>

--- a/application/feature/characters/favorite/res/src/main/AndroidManifest.xml
+++ b/application/feature/characters/favorite/res/src/main/AndroidManifest.xml
@@ -1,0 +1,1 @@
+<manifest package="com.stepango.blockme.feature.character.favorite.res"/>

--- a/application/feature/characters/list/databinding/src/main/AndroidManifest.xml
+++ b/application/feature/characters/list/databinding/src/main/AndroidManifest.xml
@@ -1,0 +1,1 @@
+<manifest package="com.stepango.blockme.feature.characters.list.databinding"/>

--- a/application/feature/characters/list/impl/src/main/AndroidManifest.xml
+++ b/application/feature/characters/list/impl/src/main/AndroidManifest.xml
@@ -1,0 +1,1 @@
+<manifest package="com.stepango.blockme.feature.characters.list.impl"/>

--- a/application/feature/characters/list/res/src/main/AndroidManifest.xml
+++ b/application/feature/characters/list/res/src/main/AndroidManifest.xml
@@ -1,0 +1,1 @@
+<manifest package="com.stepango.blockme.feature.character.list.res"/>

--- a/application/feature/home/databinding/src/main/AndroidManifest.xml
+++ b/application/feature/home/databinding/src/main/AndroidManifest.xml
@@ -1,0 +1,1 @@
+<manifest package="com.stepango.blockme.feature.home.databinding"/>

--- a/application/feature/home/impl/src/main/AndroidManifest.xml
+++ b/application/feature/home/impl/src/main/AndroidManifest.xml
@@ -1,0 +1,1 @@
+<manifest package="com.stepango.blockme.feature.home.impl"/>

--- a/application/feature/home/res/src/main/AndroidManifest.xml
+++ b/application/feature/home/res/src/main/AndroidManifest.xml
@@ -1,0 +1,1 @@
+<manifest package="com.stepango.blockme.feature.home.res"/>

--- a/application/root-res/src/main/AndroidManifest.xml
+++ b/application/root-res/src/main/AndroidManifest.xml
@@ -1,0 +1,1 @@
+<manifest package="com.stepango.blockme.rootres"/>

--- a/application/toggle-widget/src/main/AndroidManifest.xml
+++ b/application/toggle-widget/src/main/AndroidManifest.xml
@@ -1,0 +1,1 @@
+<manifest package="com.stepango.blockme.widget.toggle"/>

--- a/plugins/android/src/main/java/androidApp.kt
+++ b/plugins/android/src/main/java/androidApp.kt
@@ -41,9 +41,7 @@ fun Project.androidApp(
         buildConfiguration,
         testInstrumentationRunner,
         consumerMinificationFiles,
-        manifestPlaceholders,
-        // AndroidApp should always use custom manifest
-        generateManifest = false
+        manifestPlaceholders
     )
     applyFeatures(
         androidLibraryFeatureDefinition(libraryFeatureConfiguration),

--- a/plugins/android/src/main/java/androidLibrary.kt
+++ b/plugins/android/src/main/java/androidLibrary.kt
@@ -30,7 +30,6 @@ fun Project.androidLibrary(
     buildConfiguration: BuildConfiguration = BuildConfiguration(),
     consumerMinificationFiles: Set<String> = emptySet(),
     manifestPlaceholders: Map<String, Any> = emptyMap(),
-    generateManifest: Boolean = true
 ): TargetBuilder {
     target.validate(LibraryTargetTemplate)
     val libraryFeatureConfiguration = AndroidLibraryFeatureConfiguration(
@@ -39,7 +38,6 @@ fun Project.androidLibrary(
         testInstrumentationRunner,
         consumerMinificationFiles,
         manifestPlaceholders,
-        generateManifest
     )
     applyFeatures(
         androidLibraryFeatureDefinition(libraryFeatureConfiguration),

--- a/plugins/android/src/main/java/androidProjectConfiguration.kt
+++ b/plugins/android/src/main/java/androidProjectConfiguration.kt
@@ -7,6 +7,16 @@ import org.gradle.api.tasks.Delete
 import tools.forma.android.config.FormaConfiguration
 import tools.forma.android.utils.register
 
+// TODO: add docs for every fun param
+/**
+ * Configures common values for whole forma modules.
+ * @param minSdk is min android sdk
+ * @param targetSdk is target android sdk
+ * @param compileSdk is compile android sdk
+ * @param versionCode is version code for
+ * @param validateManifestPackages enabling validation of manifests during configuration
+ * @param generateMissedManifests enabling generation missing manifests during configuration
+ */
 fun Project.androidProjectConfiguration(
     minSdk: Int,
     targetSdk: Int,
@@ -16,6 +26,7 @@ fun Project.androidProjectConfiguration(
     repositories: RepositoryHandler.() -> Unit = {},
     dataBinding: Boolean = false,
     validateManifestPackages: Boolean = false,
+    generateMissedManifests: Boolean = false,
     javaVersionCompatibility: JavaVersion = JavaVersion.VERSION_1_8, // Java/Kotlin configuration
     mandatoryOwners: Boolean = false
 ) {
@@ -38,6 +49,7 @@ fun Project.androidProjectConfiguration(
         versionName = versionName,
         repositories = repositories,
         dataBinding = dataBinding,
+        generateMissedManifests = generateMissedManifests,
         validateManifestPackages = validateManifestPackages,
         javaVersionCompatibility = javaVersionCompatibility,
         mandatoryOwners = mandatoryOwners

--- a/plugins/android/src/main/java/androidProjectConfiguration.kt
+++ b/plugins/android/src/main/java/androidProjectConfiguration.kt
@@ -17,6 +17,7 @@ fun Project.androidProjectConfiguration(
     versionName: String,
     repositories: RepositoryHandler.() -> Unit = {},
     dataBinding: Boolean = false,
+    validateManifestPackages: Boolean = false,
     javaVersionCompatibility: JavaVersion = JavaVersion.VERSION_1_8, // Java/Kotlin configuration
     mandatoryOwners: Boolean = false
 ) {
@@ -38,6 +39,7 @@ fun Project.androidProjectConfiguration(
         versionName = versionName,
         repositories = repositories,
         dataBinding = dataBinding,
+        validateManifestPackages = validateManifestPackages,
         javaVersionCompatibility = javaVersionCompatibility,
         mandatoryOwners = mandatoryOwners
     )

--- a/plugins/android/src/main/java/tools/forma/android/config/FormaConfiguration.kt
+++ b/plugins/android/src/main/java/tools/forma/android/config/FormaConfiguration.kt
@@ -33,6 +33,7 @@ data class FormaConfiguration(
     val dataBinding: Boolean = false,
     val compose: Boolean = false,
     val validateManifestPackages: Boolean = false,
+    val generateMissedManifests: Boolean = false,
     val vectorDrawablesUseSupportLibrary: Boolean = minSdk < AndroidSdkVersion.N,
     val javaVersionCompatibility: JavaVersion = JavaVersion.VERSION_1_8, // Java/Kotlin configuration
     val mandatoryOwners: Boolean

--- a/plugins/android/src/main/java/tools/forma/android/config/FormaConfiguration.kt
+++ b/plugins/android/src/main/java/tools/forma/android/config/FormaConfiguration.kt
@@ -32,6 +32,7 @@ data class FormaConfiguration(
     // Databinding is Application level feature, android_binary will be infering dataBinding flag, developers does not need to know about
     val dataBinding: Boolean = false,
     val compose: Boolean = false,
+    val validateManifestPackages: Boolean = false,
     val vectorDrawablesUseSupportLibrary: Boolean = minSdk < AndroidSdkVersion.N,
     val javaVersionCompatibility: JavaVersion = JavaVersion.VERSION_1_8, // Java/Kotlin configuration
     val mandatoryOwners: Boolean

--- a/plugins/android/src/main/java/uiLibrary.kt
+++ b/plugins/android/src/main/java/uiLibrary.kt
@@ -36,7 +36,6 @@ fun Project.uiLibrary(
     buildConfiguration: BuildConfiguration = BuildConfiguration(),
     consumerMinificationFiles: Set<String> = emptySet(),
     manifestPlaceholders: Map<String, Any> = emptyMap(),
-    generateManifest: Boolean = true
 ): TargetBuilder {
     target.validate(UiLibraryTargetTemplate)
     val libraryFeatureConfiguration = AndroidLibraryFeatureConfiguration(
@@ -45,7 +44,6 @@ fun Project.uiLibrary(
         testInstrumentationRunner,
         consumerMinificationFiles,
         manifestPlaceholders,
-        generateManifest
     )
     applyFeatures(
         androidLibraryFeatureDefinition(libraryFeatureConfiguration),

--- a/plugins/build.gradle.kts
+++ b/plugins/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 subprojects {
     extra["kotlin_dep"] = "org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.21"
-    extra["agp_dep"] = "com.android.tools.build:gradle:7.0.0-beta04"
+    extra["agp_dep"] = "com.android.tools.build:gradle:7.0.0"
 
     repositories {
         google()


### PR DESCRIPTION
Added 2 flags to forma configuration for working with manifests:
1. Remove `generateManifest` from android targets and add `generateMissedManifests` to forma global config
2. Add `validateManifestPackages` for comparing build.gradle.kts `packageName` with manifest's `package`