### PR TITLE
Migrate to android.namespaces

### DIFF
--- a/application/build.gradle.kts
+++ b/application/build.gradle.kts
@@ -5,8 +5,6 @@ buildscript {
         targetSdk = 31,
         compileSdk = 31,
         dataBinding = true,
-        validateManifestPackages = true,
-        generateMissedManifests = true,
         extraPlugins = listOf(
             "androidx.navigation:navigation-safe-args-gradle-plugin:2.4.2",
             "com.google.firebase:firebase-crashlytics-gradle:2.5.0",

--- a/plugins/android/src/main/java/androidProjectConfiguration.kt
+++ b/plugins/android/src/main/java/androidProjectConfiguration.kt
@@ -15,9 +15,11 @@ import tools.forma.android.utils.register
  * @param minSdk is min android sdk
  * @param targetSdk is target android sdk
  * @param compileSdk SDK version used to compile Android App
- * @param versionCode is version code of the App
- * @param validateManifestPackages enabling validation of manifests during configuration
- * @param generateMissedManifests enabling generation missing manifests during configuration
+ * @param repositories is a function that configures repositories for project
+ * @param dataBinding is a flag that enables databinding
+ * @param javaVersionCompatibility is a java version that will be used for targetCompatibility and sourceCompatibility versions
+ * @param mandatoryOwners is a flag that enables mandatory owners for all modules
+ * @param extraPlugins is a list of extra plugins that will be applied to project
  */
 fun ScriptHandlerScope.androidProjectConfiguration(
     project: Project,
@@ -26,8 +28,6 @@ fun ScriptHandlerScope.androidProjectConfiguration(
     compileSdk: Int,
     repositories: RepositoryHandler.() -> Unit = {},
     dataBinding: Boolean = false,
-    validateManifestPackages: Boolean = false,
-    generateMissedManifests: Boolean = false,
     javaVersionCompatibility: JavaVersion = JavaVersion.VERSION_1_8, // Java/Kotlin configuration
     mandatoryOwners: Boolean = false,
     extraPlugins: List<Any>
@@ -51,8 +51,6 @@ fun ScriptHandlerScope.androidProjectConfiguration(
             agpVersion = properties["forma.agpVersion"]!!.toString(),
             repositories = repositories,
             dataBinding = dataBinding,
-            generateMissedManifests = generateMissedManifests,
-            validateManifestPackages = validateManifestPackages,
             javaVersionCompatibility = javaVersionCompatibility,
             mandatoryOwners = mandatoryOwners
         )
@@ -93,8 +91,6 @@ fun Project.androidProjectConfiguration(
             agpVersion = properties["forma.agpVersion"]!!.toString(),
             repositories = repositories,
             dataBinding = dataBinding,
-            generateMissedManifests = generateMissedManifests,
-            validateManifestPackages = validateManifestPackages,
             javaVersionCompatibility = javaVersionCompatibility,
             mandatoryOwners = mandatoryOwners
         )

--- a/plugins/android/src/main/java/tools/forma/android/config/FormaConfiguration.kt
+++ b/plugins/android/src/main/java/tools/forma/android/config/FormaConfiguration.kt
@@ -30,8 +30,6 @@ data class FormaConfiguration(
     // Databinding is Application level feature, android_binary will be infering dataBinding flag, developers does not need to know about
     val dataBinding: Boolean = false,
     val compose: Boolean = false,
-    val validateManifestPackages: Boolean = false,
-    val generateMissedManifests: Boolean = false,
     val vectorDrawablesUseSupportLibrary: Boolean = minSdk < AndroidSdkVersion.N,
     val javaVersionCompatibility: JavaVersion = JavaVersion.VERSION_1_8, // Java/Kotlin configuration
     val mandatoryOwners: Boolean

--- a/plugins/android/src/main/java/tools/forma/android/feature/AndroidBinary.kt
+++ b/plugins/android/src/main/java/tools/forma/android/feature/AndroidBinary.kt
@@ -28,7 +28,8 @@ fun androidBinaryFeatureDefinition(
     featureConfiguration = featureConfiguration,
     configuration = { extension, configuration, _, formaConfiguration ->
         with(extension) {
-            compileSdkVersion(formaConfiguration.compileSdk)
+            namespace = configuration.packageName
+            compileSdk = formaConfiguration.compileSdk
 
             defaultConfig.applicationId = configuration.packageName
             defaultConfig.versionCode = configuration.versionCode

--- a/plugins/android/src/main/java/tools/forma/android/feature/AndroidLibrary.kt
+++ b/plugins/android/src/main/java/tools/forma/android/feature/AndroidLibrary.kt
@@ -2,17 +2,12 @@ package tools.forma.android.feature
 
 import androidJunitRunner
 import com.android.build.gradle.LibraryExtension
-import org.gradle.api.Project
 import org.gradle.kotlin.dsl.get
-import org.gradle.kotlin.dsl.support.listFilesOrdered
-import org.xml.sax.InputSource
 import tools.forma.android.target.LibraryTargetTemplate
 import tools.forma.android.utils.BuildConfiguration
 import tools.forma.android.utils.applyFrom
 import tools.forma.validation.Validator
 import tools.forma.validation.validator
-import java.io.File
-import javax.xml.parsers.DocumentBuilderFactory
 
 class AndroidLibraryFeatureConfiguration(
     val packageName: String,
@@ -31,14 +26,9 @@ fun androidLibraryFeatureDefinition(
     pluginName = "com.android.library",
     pluginExtension = LibraryExtension::class,
     featureConfiguration = featureConfiguration,
-    configuration = { extension, feature, project, formaConfiguration ->
+    configuration = { extension, feature, _, formaConfiguration ->
         with(extension) {
-            if (formaConfiguration.generateMissedManifests) {
-                maybeGenerateManifest(project, feature)
-            }
-            if (formaConfiguration.validateManifestPackages) {
-                validateManifestPackage(feature.packageName, project)
-            }
+            namespace = feature.packageName
             compileSdk = formaConfiguration.compileSdk
 
             defaultConfig.applyFrom(
@@ -60,75 +50,3 @@ fun androidLibraryFeatureDefinition(
         }
     }
 )
-
-private fun LibraryExtension.validateManifestPackage(
-    packageName: String,
-    project: Project
-) {
-    sourceSets.forEach {
-        if (it.manifest.srcFile.exists()) {
-            val manifestPackageName = DocumentBuilderFactory
-                .newInstance()
-                .newDocumentBuilder()
-                .parse(InputSource(it.manifest.srcFile.reader()))
-                .documentElement
-                .getAttribute("package")
-
-            if (manifestPackageName != packageName) {
-                error(
-                    "Manifest package != build.gradle.kts packageName, it must be equal" +
-                            "\nmanifest ${it.manifest.srcFile.absolutePath}" +
-                            "\npackage $manifestPackageName" +
-                            "\nbuild script ${project.buildFile.absolutePath}" +
-                            "\npackageName $packageName"
-                )
-            }
-        }
-    }
-}
-
-private fun LibraryExtension.maybeGenerateManifest(
-    project: Project,
-    feature: AndroidLibraryFeatureConfiguration
-) {
-    val srcDir = File(project.projectDir, "src")
-    val mainDir = File(srcDir, "main")
-    // other source sets inherit manifest in case of existing main manifest
-    if (mainDir.isDirectory && mainDir.exists()) {
-        populateManifest(File(mainDir, "AndroidManifest.xml"), feature.packageName)
-    } else {
-        val sourceSetNames = sourceSets.names
-        srcDir
-            .listFilesOrdered { it.name in sourceSetNames && it.isDirectory }
-            .forEach {
-                populateManifest(File(it, "AndroidManifest.xml"), feature.packageName)
-            }
-    }
-}
-
-/**
- * Manifest file generated and added it to sourceSet
- * @param buildDir - project's build dir
- * @param packageName - will be injected to manifest template
- * @return path to generated file
- */
-private fun populateManifest(
-    manifestFile: File,
-    packageName: String
-): String {
-    /**
-     * Some naive caching here, file name equals package name
-     * We create new file only if package is changed or on first build
-     */
-    with(manifestFile) {
-        if (!exists()) {
-            parentFile.mkdirs()
-            createNewFile()
-            writeText(
-                "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n" +
-                        "<manifest package=\"$packageName\"/>"
-            )
-        }
-    }
-    return manifestFile.path
-}

--- a/plugins/android/src/main/java/tools/forma/android/feature/AndroidNative.kt
+++ b/plugins/android/src/main/java/tools/forma/android/feature/AndroidNative.kt
@@ -22,9 +22,10 @@ fun androidNativeDefinition(
     pluginName = "com.android.library",
     pluginExtension = LibraryExtension::class,
     featureConfiguration = configuration,
-    configuration = { extension, feature, _, formaConfiguration ->
+    configuration = { extension, _, _, formaConfiguration ->
         with(extension) {
-            compileSdkVersion(formaConfiguration.compileSdk)
+            namespace = configuration.packageName
+            compileSdk = formaConfiguration.compileSdk
 
             defaultConfig.applyFrom(
                 formaConfiguration,


### PR DESCRIPTION
- Remove flags to generate and validate AndroidManifest.xml
- Set android.namespace to packageName instead of generating AndroidManifest.xml

Partial cherry-pick from https://github.com/tinkoff-mobile-tech/forma/pull/13 by @Jacks0N23