### PR TITLE
Fix `tools.forma.includer` plugin behavior

### DIFF
--- a/application/settings.gradle.kts
+++ b/application/settings.gradle.kts
@@ -1,5 +1,3 @@
-import org.gradle.api.internal.artifacts.dependencies.DefaultDependencyConstraint.strictly
-
 pluginManagement {
     apply(
         from =
@@ -18,6 +16,8 @@ plugins {
     id("tools.forma.deps")
     id("tools.forma.depgen")
 }
+
+includer { arbitraryBuildScriptNames = true }
 
 rootProject.name = "application"
 
@@ -58,7 +58,7 @@ dependencyResolutionManagement {
             addPlugin("tools.forma.demo:dependencies", "0.0.1")
             addPlugin(
                 "com.google.devtools.ksp",
-                "1.8.10-1.0.9",
+                "$embeddedKotlinVersion-1.0.9",
                 "androidx.room:room-compiler:$roomVersion"
             )
         }

--- a/includer/Changelog.md
+++ b/includer/Changelog.md
@@ -1,3 +1,7 @@
+# 0.2.0 Minor patch release
+
+- Includer configuration extension added
+
 # 0.1.3 Minor patch release
 
 - Prevent traversing nested projects

--- a/includer/Readme.md
+++ b/includer/Readme.md
@@ -16,9 +16,7 @@ plugins {
 # How does it work?
 
 Includer traverses the project's file tree and includes as subprojects all directories that have 
-files with `.gradle(.kts)` extensions. The plugin looks for more than just `build.gradle(.kts)` by default. 
-Because in large projects it may be necessary to use different build file names to make it 
-easier to search for them by name.
+files with `build.gradle(.kts)` files.
 
 Includer skips directories that have `settings.gradle(.kts)` files, treating them as nested projects.
 
@@ -34,27 +32,35 @@ rootProject
 |
 |--feature1
 |----api <- will be included as :feature1-api
-|------api.gradle.kts
+|------build.gradle.kts
 ```
 
 # Plugin configuration
 
-The plugin is configurable by specifying properties in the `gradle.properties` file.
+The plugin is configurable by specifying properties in the `includer` extension.
 
 ## Ignored folders
 
 Includer always skips directories with following names: `build`, `src`, `buildSrc`. But you can 
 specify additional ignored folder names:
 
-```properties
-tools.forma.includer.ignoredFolders=.cmake_cache,.gradle,gradle
+```kotlin
+// in settings.gradle.kts file after `plugins` block
+includer {
+    excludeFolders(".cmake_cache", "scripts")
+}
 ```
 
 ## Arbitrary build file names
 
-If in your case arbitrary build file names interfere with proper project configuration, 
-you can disable this option:
+If you want the plugin to look for any `*.gradle(.kts)` files, not just `build.gradle(.kts)`:
 
-```properties
-tools.forma.includer.arbitraryBuildFileNames=false
+```kotlin
+// in settings.gradle.kts file after `plugins` block
+includer {
+    arbitraryBuildScriptNames = true
+}
 ```
+
+> NOTE: If you use this property, there can only be one `*.gradle(.kts)` file in the root 
+> of any module.

--- a/includer/Readme.md
+++ b/includer/Readme.md
@@ -1,6 +1,7 @@
 # Includer
 
-Simple and powerful plugin which helps you to save time and avoid writing tons of boilerplate code. Uses kotlin coroutines to efficiently traverse even deeply nested project trees.
+Simple and powerful plugin which helps you to save time and avoid writing tons of boilerplate code. 
+Uses kotlin coroutines to efficiently traverse even deeply nested project trees.
 
 ## Installation
 
@@ -10,4 +11,50 @@ Remove all your `include` declarations from your `settings.gradle.kts` file and 
 plugins {
     id("tools.forma.includer") version "0.1.3"
 }
+```
+
+# How does it work?
+
+Includer traverses the project's file tree and includes as subprojects all directories that have 
+files with `.gradle(.kts)` extensions. The plugin looks for more than just `build.gradle(.kts)` by default. 
+Because in large projects it may be necessary to use different build file names to make it 
+easier to search for them by name.
+
+Includer skips directories that have `settings.gradle(.kts)` files, treating them as nested projects.
+
+Example:
+
+```
+rootProject
+|--app <- will be included as :app
+|----build.gradle.kts
+|
+|--build-logic <- will be ignored
+|----settings.gradle.kts
+|
+|--feature1
+|----api <- will be included as :feature1-api
+|------api.gradle.kts
+```
+
+# Plugin configuration
+
+The plugin is configurable by specifying properties in the `gradle.properties` file.
+
+## Ignored folders
+
+Includer always skips directories with following names: `build`, `src`, `buildSrc`. But you can 
+specify additional ignored folder names:
+
+```properties
+tools.forma.includer.ignoredFolders=.cmake_cache,.gradle,gradle
+```
+
+## Arbitrary build file names
+
+If in your case arbitrary build file names interfere with proper project configuration, 
+you can disable this option:
+
+```properties
+tools.forma.includer.arbitraryBuildFileNames=false
 ```

--- a/includer/plugin/build.gradle.kts
+++ b/includer/plugin/build.gradle.kts
@@ -14,7 +14,6 @@ repositories {
 
 dependencies {
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4")
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-jdk8:1.6.4")
 }
 
 val javaLanguageVersion = JavaLanguageVersion.of(11)

--- a/includer/plugin/build.gradle.kts
+++ b/includer/plugin/build.gradle.kts
@@ -1,11 +1,11 @@
 @file:Suppress("UnstableApiUsage")
 
 plugins {
-    id("com.gradle.plugin-publish") version "1.1.0"
+    id("com.gradle.plugin-publish") version "1.2.0"
     id("org.jetbrains.kotlin.jvm") version embeddedKotlinVersion
 }
 
-version = "0.1.3"
+version = "0.2.0"
 group = "tools.forma"
 
 repositories {
@@ -13,7 +13,7 @@ repositories {
 }
 
 dependencies {
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.2")
 }
 
 val javaLanguageVersion = JavaLanguageVersion.of(11)
@@ -33,19 +33,18 @@ testing {
     suites {
         // Configure the built-in test suite
         val test by getting(JvmTestSuite::class) {
-            // Use Kotlin Test test framework
+            // Use Kotlin Test framework
             useKotlinTest(embeddedKotlinVersion)
         }
 
         // Create a new test suite
         val functionalTest by registering(JvmTestSuite::class) {
-            // Use Kotlin Test test framework
+            // Use Kotlin Test framework
             useKotlinTest(embeddedKotlinVersion)
 
             dependencies {
                 // functionalTest test suite depends on the production code in tests
                 implementation(project())
-                // implementation("org.gradle:gradle-test-kit:${gradle.gradleVersion}")
             }
 
             targets {

--- a/includer/plugin/src/main/kotlin/Dsl.kt
+++ b/includer/plugin/src/main/kotlin/Dsl.kt
@@ -1,0 +1,5 @@
+import org.gradle.api.initialization.Settings
+import tools.forma.includer.IncluderExtension
+
+fun Settings.includer(action: IncluderExtension.() -> Unit) =
+    extensions.getByType(IncluderExtension::class.java).action()

--- a/includer/plugin/src/main/kotlin/tools/forma/includer/IncluderExtension.kt
+++ b/includer/plugin/src/main/kotlin/tools/forma/includer/IncluderExtension.kt
@@ -1,0 +1,30 @@
+package tools.forma.includer
+
+abstract class IncluderExtension {
+
+    /**
+     * Folder names to be excluded when searching for submodules.
+     *
+     * Default set it: `build`, `src`, `buildSrc`
+     */
+    var excludeFolders: Set<String> = DEFAULT_EXCLUDED_FOLDERS
+
+    /**
+     * If true, include directories with any `.gradle(.kts)` files as modules.
+     *
+     * If false, only include directories with `build.gradle(.kts)` files as modules.
+     */
+    var arbitraryBuildScriptNames: Boolean = false
+
+    /**
+     * Add folder names to be excluded when searching for submodules
+     */
+    fun excludeFolders(vararg names: String) {
+        excludeFolders = excludeFolders + names
+    }
+
+    private companion object {
+
+        private val DEFAULT_EXCLUDED_FOLDERS = setOf("build", "src", "buildSrc")
+    }
+}

--- a/includer/plugin/src/main/kotlin/tools/forma/includer/IncluderExtension.kt
+++ b/includer/plugin/src/main/kotlin/tools/forma/includer/IncluderExtension.kt
@@ -16,15 +16,12 @@ abstract class IncluderExtension {
      */
     var arbitraryBuildScriptNames: Boolean = false
 
-    /**
-     * Add folder names to be excluded when searching for submodules
-     */
+    /** Add folder names to be excluded when searching for submodules */
     fun excludeFolders(vararg names: String) {
         excludeFolders = excludeFolders + names
     }
 
     private companion object {
-
         private val DEFAULT_EXCLUDED_FOLDERS = setOf("build", "src", "buildSrc")
     }
 }

--- a/includer/plugin/src/main/kotlin/tools/forma/includer/IncluderPlugin.kt
+++ b/includer/plugin/src/main/kotlin/tools/forma/includer/IncluderPlugin.kt
@@ -1,7 +1,5 @@
 package tools.forma.includer
 
-import java.io.File
-import kotlin.system.measureTimeMillis
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
@@ -12,6 +10,8 @@ import org.gradle.api.initialization.Settings
 import org.gradle.api.logging.LogLevel
 import org.gradle.api.logging.Logger
 import org.gradle.api.logging.Logging
+import java.io.File
+import kotlin.system.measureTimeMillis
 
 val logger: Logger = Logging.getLogger(IncluderPlugin::class.java)
 
@@ -20,84 +20,54 @@ val logger: Logger = Logging.getLogger(IncluderPlugin::class.java)
  * build.
  */
 class IncluderPlugin : Plugin<Settings> {
+
     override fun apply(settings: Settings) {
-        includeSubprojects(settings)
+        settings.includeSubprojects()
     }
-}
 
-private fun includeSubprojects(settings: Settings) {
-    val measuredTime = measureTimeMillis {
-        runBlocking { findGradleKtsFiles(settings.rootDir, settings.rootDir) }
-            .forEach { buildFile ->
-                val moduleDir = buildFile.parentFile
-                val relativePath =
-                    settings.rootDir.toPath().relativize(moduleDir.toPath()).toString()
-                // Avoid using `:` as separator for module names as it is used by gradle to
-                // mark
-                // intermittent nested projects, which created automatically. This behavior
-                // leads to increased configuration time
-                val moduleName = ":" + relativePath.replace(File.separator, "-")
+    private fun Settings.includeSubprojects() {
+        val measuredTime = measureTimeMillis {
+            runBlocking { rootDir.findBuildGradleFiles(root = true) }
+                .forEach { buildFile ->
+                    val moduleDir = buildFile.parentFile
+                    val relativePath = moduleDir.relativeTo(rootDir).path
+                    // Avoid using `:` as separator for module names as it is used by gradle to mark
+                    // intermittent nested projects, which created automatically. This behavior
+                    // leads to increased configuration time
+                    val moduleName = ":$relativePath".replace(File.separator, "-")
 
-                settings.include(moduleName)
-
-                val project = settings.findProject(moduleName)!!
-                project.projectDir = moduleDir
-                project.buildFileName = buildFile.name
-            }
-    }
-    logger.log(LogLevel.INFO, "Loaded in $measuredTime ms")
-}
-
-/**
- * Recursively finds all gradle files in the given directory, excluding the hidden files, given
- * filenames and folders.
- *
- * Ignores nested projects if the current directory contains a file from the `projectMarkerFiles`
- * list.
- *
- * @param rootDir root directory of the project
- * @param currentDir current directory to search
- * @param ignoredFilenames list of filenames to ignore
- * @param ignoredFolders list of folder names to ignore
- * @param projectMarkerFiles filenames that indicate that the directory as a gradle project
- */
-private suspend fun findGradleKtsFiles(
-    rootDir: File,
-    currentDir: File,
-    ignoredFilenames: List<String> = emptyList(),
-    ignoredFolders: List<String> = listOf("build", "src", "buildSrc"),
-    projectMarkerFiles: List<String> = listOf("settings.gradle.kts", "settings.gradle"),
-): List<File> = coroutineScope {
-    val children = currentDir.listFiles() ?: emptyArray()
-
-    val (dirs, files) = children.partition { it.isDirectory }
-
-    val gradleKtsFiles =
-        if (currentDir == rootDir) {
-            // Root project's build.gradle(.kts) always included implicitly
-            emptyList()
-        } else {
-            files
-                // gradle files may have name that is different from `build.gradle(.kts)` so we
-                // include files which follows `*.gradle(.kts)` pattern
-                .filter { it.name.endsWith(".gradle.kts") || it.name.endsWith(".gradle") }
-                .filterNot { it.isHidden || it.name in ignoredFilenames }
-        }
-
-    val skipNestedProject = currentDir != rootDir && files.any { it.name in projectMarkerFiles }
-
-    if (skipNestedProject) {
-        gradleKtsFiles
-    } else {
-        gradleKtsFiles +
-            dirs
-                .filterNot { it.isHidden || it.name in ignoredFolders }
-                .map { dir ->
-                    async(Dispatchers.IO) {
-                        findGradleKtsFiles(rootDir, dir, ignoredFilenames, ignoredFolders)
+                    include(moduleName)
+                    with(project(moduleName)) {
+                        projectDir = moduleDir
+                        buildFileName = buildFile.name
                     }
                 }
-                .awaitAll()
-                .flatten()
+        }
+        logger.log(LogLevel.INFO, "Loaded in $measuredTime ms")
+    }
+
+    private suspend fun File.findBuildGradleFiles(root: Boolean = true): List<File> =
+        coroutineScope {
+            val (dirs, files) = listFiles().partition { it.isDirectory }
+
+            if (!root && files.any { it.name in PROJECT_MARKER_FILES })
+                return@coroutineScope emptyList()
+
+            files.filter { !root && it.name in BUILD_GRADLE_FILES } +
+                    dirs.filterNot { it.isHidden || it.name in IGNORED_FOLDERS }
+                        .map { dir ->
+                            async(Dispatchers.IO) {
+                                dir.findBuildGradleFiles(root = false)
+                            }
+                        }
+                        .awaitAll()
+                        .flatten()
+        }
+
+    companion object {
+
+        private val BUILD_GRADLE_FILES = setOf("build.gradle.kts", "build.gradle")
+        private val PROJECT_MARKER_FILES = setOf("settings.gradle.kts", "settings.gradle")
+        private val IGNORED_FOLDERS = setOf("build", "src", "buildSrc", ".gradle")
     }
 }

--- a/includer/plugin/src/main/kotlin/tools/forma/includer/IncluderPlugin.kt
+++ b/includer/plugin/src/main/kotlin/tools/forma/includer/IncluderPlugin.kt
@@ -21,13 +21,40 @@ val logger: Logger = Logging.getLogger(IncluderPlugin::class.java)
  */
 class IncluderPlugin : Plugin<Settings> {
 
+    private class Options(
+        val ignoredFolders: Set<String>,
+        val arbitraryBuildFileNames: Boolean,
+    )
+
     override fun apply(settings: Settings) {
-        settings.includeSubprojects()
+        with(settings) {
+            includeSubprojects(loadOptions())
+        }
     }
 
-    private fun Settings.includeSubprojects() {
+    private fun Settings.loadOptions(): Options {
+        val ext = extensions.extraProperties.properties
+
+        // Comma separated list of folder names
+        val ignoredFolders = ext["tools.forma.includer.ignoredFolders"]
+            ?.toString()
+            ?.split(',')
+            ?.map { it.trim() }
+            .orEmpty()
+
+        // Default is "true"
+        val arbitraryBuildFileNames = ext["tools.forma.includer.arbitraryBuildFileNames"]
+            ?.toString() != "false"
+
+        return Options(
+            ignoredFolders = IGNORED_FOLDERS + ignoredFolders.toSet(),
+            arbitraryBuildFileNames = arbitraryBuildFileNames,
+        )
+    }
+
+    private fun Settings.includeSubprojects(options: Options) {
         val measuredTime = measureTimeMillis {
-            runBlocking { rootDir.findBuildGradleFiles(root = true) }
+            runBlocking { rootDir.findBuildFiles(options) }
                 .forEach { buildFile ->
                     val moduleDir = buildFile.parentFile
                     val relativePath = moduleDir.relativeTo(rootDir).path
@@ -46,28 +73,58 @@ class IncluderPlugin : Plugin<Settings> {
         logger.log(LogLevel.INFO, "Loaded in $measuredTime ms")
     }
 
-    private suspend fun File.findBuildGradleFiles(root: Boolean = true): List<File> =
+    private suspend fun File.findBuildFiles(options: Options, root: Boolean = true): List<File> =
         coroutineScope {
             val (dirs, files) = listFiles().partition { it.isDirectory }
 
+            // Completely ignore the project with the settings file and all its child directories
             if (!root && files.any { it.name in PROJECT_MARKER_FILES })
                 return@coroutineScope emptyList()
 
-            files.filter { !root && it.name in BUILD_GRADLE_FILES } +
-                    dirs.filterNot { it.isHidden || it.name in IGNORED_FOLDERS }
+            files.filterBuildFiles(options, root) +
+                    dirs.filterNot { it.isHidden || it.name in options.ignoredFolders }
                         .map { dir ->
                             async(Dispatchers.IO) {
-                                dir.findBuildGradleFiles(root = false)
+                                dir.findBuildFiles(options, root = false)
                             }
                         }
                         .awaitAll()
                         .flatten()
         }
 
+    private fun List<File>.filterBuildFiles(options: Options, root: Boolean): List<File> {
+        if (root) return emptyList()
+
+        val buildFiles =
+            if (options.arbitraryBuildFileNames) {
+                filter { it.name.endsWith(".gradle.kts") || it.name.endsWith(".gradle") }
+            } else {
+                filter { it.name in BUILD_GRADLE_FILES }
+            }
+
+        // Make sure that we found the only build file in the directory or did not find it at all
+        // Thus, we prevent the addition of the same module by several build files
+        if (buildFiles.isEmpty() || buildFiles.size == 1) {
+            return buildFiles
+        } else {
+            // If more than one build file is found, we inform the developer about the conflict
+            val parentDir = buildFiles.first().parentFile
+            error(
+                buildString {
+                    appendLine("Directory $parentDir has more than one gradle build file:")
+                    buildFiles.forEach { appendLine("- ${it.name}") }
+                    appendLine("Leave only one .gradle(.kts) file, or use the " +
+                            "`tools.forma.includer.arbitraryBuildFileNames=false` setting " +
+                            "to ignore any build files other than build.gradle(.kts).")
+                }
+            )
+        }
+    }
+
     companion object {
 
         private val BUILD_GRADLE_FILES = setOf("build.gradle.kts", "build.gradle")
         private val PROJECT_MARKER_FILES = setOf("settings.gradle.kts", "settings.gradle")
-        private val IGNORED_FOLDERS = setOf("build", "src", "buildSrc", ".gradle")
+        private val IGNORED_FOLDERS = setOf("build", "src", "buildSrc")
     }
 }


### PR DESCRIPTION
Fixed some problems of the Includer plugin that prevent its integration with our project:

- Skip including nested projects.
  **Current behavior**: nested projects with `settings.gradle(.kts)` are not added, but their subprojects are added.
  **New behavior**: nested projects with `settings.gradle(.kts)` and their subprojects are completely skipped.
- Make plugin configurable:
  - Allowed to disable arbitrary build file names with property `tools.forma.includer.arbitraryBuildFileNames`. For those cases when we want the plugin to include only modules with `build.gradle(.kts)` files.
  - Allowed to specify additional folder names to ignore with property `tools.forma.includer.ignoredFolders`.
- Fail project configuration if a module with more than one build file is encountered (with a very clear error description).
- Extend `IncluderPluginFunctionalTest` to cover all plugin use cases.