### PR TITLE
Fixed a bug with configuration cache invalidation in Includer

### DIFF
--- a/includer/plugin/build.gradle.kts
+++ b/includer/plugin/build.gradle.kts
@@ -12,10 +12,6 @@ repositories {
     mavenCentral()
 }
 
-dependencies {
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.2")
-}
-
 val javaLanguageVersion = JavaLanguageVersion.of(11)
 kotlin {
     jvmToolchain {

--- a/includer/plugin/src/functionalTest/kotlin/tools/forma/includer/IncluderPluginFunctionalTest.kt
+++ b/includer/plugin/src/functionalTest/kotlin/tools/forma/includer/IncluderPluginFunctionalTest.kt
@@ -120,11 +120,11 @@ class IncluderPluginFunctionalTest {
         assertTrue("Should include ':app' project") {
             result.output.contains("Project ':app'")
         }
-        assertTrue("Should include ':feature1-api' project" +
+        assertTrue("Should include ':feature1-api' project " +
                 "because 'arbitraryBuildScriptNames = true'") {
             result.output.contains("Project ':feature1-api'")
         }
-        assertTrue("Should include ':feature1-impl' project" +
+        assertTrue("Should include ':feature1-impl' project " +
                 "because 'arbitraryBuildScriptNames = true'") {
             result.output.contains("Project ':feature1-impl'")
         }

--- a/includer/plugin/src/main/kotlin/tools/forma/includer/IncluderPlugin.kt
+++ b/includer/plugin/src/main/kotlin/tools/forma/includer/IncluderPlugin.kt
@@ -1,16 +1,14 @@
 package tools.forma.includer
 
-import java.io.File
-import kotlin.system.measureTimeMillis
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.async
-import kotlinx.coroutines.awaitAll
-import kotlinx.coroutines.coroutineScope
-import kotlinx.coroutines.runBlocking
 import org.gradle.api.Plugin
+import org.gradle.api.file.FileCollection
 import org.gradle.api.initialization.Settings
 import org.gradle.api.logging.Logger
 import org.gradle.api.logging.Logging
+import org.gradle.api.model.ObjectFactory
+import java.io.File
+import javax.inject.Inject
+import kotlin.system.measureTimeMillis
 
 val logger: Logger = Logging.getLogger(IncluderPlugin::class.java)
 
@@ -18,7 +16,9 @@ val logger: Logger = Logging.getLogger(IncluderPlugin::class.java)
  * Once applied, Includer will search for nested projects and automatically includes them in the
  * build.
  */
-abstract class IncluderPlugin : Plugin<Settings> {
+abstract class IncluderPlugin @Inject constructor(
+    private val factory: ObjectFactory,
+) : Plugin<Settings> {
 
     override fun apply(settings: Settings) {
         with(settings) {
@@ -30,7 +30,17 @@ abstract class IncluderPlugin : Plugin<Settings> {
 
     private fun Settings.includeSubprojects(extension: IncluderExtension) {
         val measuredTime = measureTimeMillis {
-            runBlocking { rootDir.findBuildFiles(extension) }
+            // Nested projects is a projects with settings script in their directory
+            val nestedProjects =
+                factory.querySettingsGradleFiles(rootDir).map { it.parentFile }
+
+            factory
+                .queryBuildGradleFiles(
+                    rootDir = rootDir,
+                    nestedProjects = nestedProjects,
+                    extension = extension,
+                )
+                .validateDuplicates(extension)
                 .forEach { buildFile ->
                     val moduleDir = buildFile.parentFile
                     val relativePath = moduleDir.relativeTo(rootDir).path
@@ -49,63 +59,60 @@ abstract class IncluderPlugin : Plugin<Settings> {
         logger.info("Loaded in $measuredTime ms")
     }
 
-    private suspend fun File.findBuildFiles(
+    private fun ObjectFactory.querySettingsGradleFiles(rootDir: File): FileCollection =
+        fileTree()
+            .from(rootDir)
+            .apply { include(*SETTINGS_GRADLE_FILES) }
+            .filter { it.parentFile != rootDir }
+
+    private fun ObjectFactory.queryBuildGradleFiles(
+        rootDir: File,
+        nestedProjects: List<File>,
         extension: IncluderExtension,
-        root: Boolean = true,
-    ): List<File> = coroutineScope {
-        val (dirs, files) =
-            listFiles()?.partition { it.isDirectory } ?: Pair(emptyList(), emptyList())
-
-        // Completely ignore the project with the settings file and all its child directories
-        if (!root && files.any { it.name in PROJECT_MARKER_FILES })
-            return@coroutineScope emptyList()
-
-        files.filterBuildFiles(extension, root) +
-            dirs
-                .filterNot { it.isHidden || it.name in extension.excludeFolders }
-                .map { dir ->
-                    async(Dispatchers.IO) { dir.findBuildFiles(extension, root = false) }
+    ): FileCollection =
+        fileTree()
+            .from(rootDir)
+            .apply {
+                if (extension.arbitraryBuildScriptNames) {
+                    include(*ANY_GRADLE_FILES)
+                    exclude(*SETTINGS_GRADLE_FILES)
+                } else {
+                    include(*BUILD_GRADLE_FILES)
                 }
-                .awaitAll()
-                .flatten()
-    }
-
-    private fun List<File>.filterBuildFiles(
-        extension: IncluderExtension,
-        root: Boolean,
-    ): List<File> {
-        if (root) return emptyList()
-
-        val buildFiles =
-            if (extension.arbitraryBuildScriptNames) {
-                filter { it.name.endsWith(".gradle.kts") || it.name.endsWith(".gradle") }
-            } else {
-                filter { it.name in BUILD_GRADLE_FILES }
+                val nestedProjectRelativePaths = nestedProjects.map { it.toRelativeString(rootDir) }
+                excludes += nestedProjectRelativePaths.map { "$it/**" } +
+                    extension.excludeFolders.map { "**/$it/**" }
             }
+            .filter { it.parentFile != rootDir }
 
-        // Make sure that we found the only build file in the directory or did not find it at all
-        // Thus, we prevent the addition of the same module by several build files
-        if (buildFiles.isEmpty() || buildFiles.size == 1) {
-            return buildFiles
-        } else {
-            // If more than one build file is found, we inform the developer about the conflict
-            val parentDir = buildFiles.first().parentFile
-            error(
-                buildString {
-                    appendLine("Directory $parentDir has more than one gradle build file:")
-                    buildFiles.forEach { appendLine("- ${it.name}") }
-                    appendLine(
+    /**
+     * The Gradle FileTree API does not guarantee the order of elements,
+     * so we find several build scripts in one directory by remembering previous elements.
+     */
+    private fun Iterable<File>.validateDuplicates(
+        extension: IncluderExtension,
+    ): Iterable<File> {
+        if (!extension.arbitraryBuildScriptNames) return this
+
+        val subprojectDirs = mutableSetOf<File>()
+        return onEach { gradleScript ->
+            val subprojectDir = gradleScript.parentFile
+            if (subprojectDir !in subprojectDirs) {
+                subprojectDirs += subprojectDir
+            } else {
+                error(
+                    "Directory $subprojectDir has more than one gradle build file. " +
                         "Leave only one .gradle(.kts) file, or use the " +
-                            "`arbitraryBuildScriptNames = false` setting " +
-                            "to ignore any build files other than build.gradle(.kts)."
-                    )
-                }
-            )
+                        "`arbitraryBuildScriptNames = false` setting " +
+                        "to ignore any build files other than build.gradle(.kts)."
+                )
+            }
         }
     }
 
     companion object {
-        private val BUILD_GRADLE_FILES = setOf("build.gradle.kts", "build.gradle")
-        private val PROJECT_MARKER_FILES = setOf("settings.gradle.kts", "settings.gradle")
+        private val ANY_GRADLE_FILES = arrayOf("**/*.gradle.kts", "**/*.gradle")
+        private val BUILD_GRADLE_FILES = arrayOf("**/build.gradle.kts", "**/build.gradle")
+        private val SETTINGS_GRADLE_FILES = arrayOf("**/settings.gradle.kts", "**/settings.gradle")
     }
 }


### PR DESCRIPTION
**Context**

Starting from Gradle 8.3, calling the isFile/isDirectory and exists() methods adds files to configuration inputs. The Includer plugin used these methods under the hood to find submodules. Because of this, any changes to files in the project led to invalidation of the configuration cache.

**How to fix?**

Migrate Includer to Gradle FileTree API